### PR TITLE
docs: document prerender deploy invariants and refresh CONTRIBUTING guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,19 +54,21 @@ Once you have an assigned issue:
 - [Node.js](https://nodejs.org/) (we recommend using Volta for version management)
   - [Volta](https://volta.sh/) - for consistent Node.js and npm versions
 - [Supabase CLI](https://supabase.com/docs/guides/local-development/cli/getting-started) - to start supabase and setup all databases locally.
-- (Optional) [Cursor](https://cursor.sh/) - recommended IDE as our project has specific Cursor configurations, we have specific Cursor configurations in the `.cursor/rules/` directory that help maintain consistent development practices.
+- (Optional) An AI-assisted editor — the repo ships a `CLAUDE.md` at the root documenting the real tech stack, architecture, and conventions. Claude Code (and similar tools) read it automatically; it's also worth reading by hand before your first contribution.
 
 ## Setting Up Volta
 
-We use Volta to ensure consistent Node.js and npm versions across the development team:
+We use Volta to ensure consistent Node.js and npm versions across the development team. The active Node version is **pinned to 24** (`package.json` `volta` field + `.nvmrc`), matching CI:
 
 ```bash
 # Install Volta
 curl https://get.volta.sh | bash
 
-# Install Node.js through Volta
-volta install node
+# Install the pinned Node.js version through Volta
+volta install node@24
 ```
+
+If you prefer `nvm`, run `nvm use` to pick up the version from `.nvmrc`.
 
 ## Running SIM Weekly Prayer Locally
 
@@ -88,18 +90,19 @@ After forking and cloning the repository (see "Getting Started" section above):
    echo "VITE_SUPABASE_ANON_KEY=$(supabase status | grep "anon key:" | awk '{print $3}')" >> .env.local
    ```
 
-2. Install dependencies: `npm install --legacy-peer-deps`
-3. Setup husky: `npm prepare`
-4. Start the development server: `npm run dev`
+2. Install dependencies: `npm install` (no `--legacy-peer-deps` needed — React runtime and types are aligned on 19, so peer deps resolve cleanly)
+3. Set up Husky git hooks: `npm run prepare`
+4. Start the development server: `npm run dev` (serves on <http://localhost:8080>)
 
 ## Contribution Involving DB Migration
 
 After testing is done properly in local db, we need to generate migration,
 see [Official Docs](https://supabase.com/docs/reference/cli/supabase-db) for more comprehensive guide.
 
-1. `supabase link --project-ref cbqslwwonnlkvblpvyrc`
-2. `supabase db diff -f supabase/migrations/{timesyamp}_{meaningfulname}.sql`
-3. remember to commit the migration file together with your pr.
+1. `supabase link --project-ref qunrljxtjzdrxkzbbkbx` (matches `supabase/config.toml`)
+2. `supabase db diff -f supabase/migrations/{timestamp}_{meaningful_name}.sql`
+3. Regenerate the TypeScript types after a schema change (`supabase gen types typescript ...`) rather than hand-editing `src/integrations/supabase/types.ts`.
+4. Remember to commit the migration file (and regenerated types) together with your PR.
 
 ## Development Workflow
 
@@ -113,31 +116,41 @@ see [Official Docs](https://supabase.com/docs/reference/cli/supabase-db) for mor
 
 2. Make your changes
 
-3. Run tests and linting before committing:
+3. Run the quality gates before committing — these mirror CI exactly (`.github/workflows/ci.yml`):
 
    ```bash
-   npm run format
-   npm run lint:fix
-   npm run test
+   npm run format        # or `npm run format:check` to verify without writing
+   npm run lint          # `npm run lint:fix` to auto-fix
+   npm run build
    ```
 
-   **Testing Guidelines:**
+   There is **no test runner** configured; CI's three gates are `format:check`, `lint`, and `build`, run on Node 24. Husky + lint-staged also run ESLint/Prettier on staged files at commit time — don't bypass them with `--no-verify`.
 
-   - All RLS (Row Level Security) policies must be tested
-   - Run `npm run test:rls` to run only RLS-specific tests
-   - For detailed testing documentation, patterns, and best practices, see our [Test Documentation](../tests/README.md)
-
-4. Commit your changes using [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) messages.
+4. Commit your changes using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) messages. **This is mandatory** — release-please parses commit messages to generate `CHANGELOG.md` and version bumps, so a non-conforming message either lands in the wrong changelog section or is dropped from release notes entirely.
 
    ```text
    <type>: <short summary>
    ```
 
+   Recognized `<type>` values (must match one; same set used for branch prefixes above):
+
+   | Type       | Use for                                              |
+   | ---------- | ---------------------------------------------------- |
+   | `feat`     | A new user-facing feature                            |
+   | `fix`      | A bug fix                                            |
+   | `build`    | Build system, dependencies, or tooling changes       |
+   | `chore`    | Maintenance that doesn't touch src or tests          |
+   | `refactor` | Code change that neither fixes a bug nor adds a feature |
+   | `docs`     | Documentation only                                   |
+   | `test`     | Adding or correcting tests                           |
+
    Examples:
 
    - `feat: add new prayer entry feature`
    - `fix: resolve bug in edit prayer form`
-   - Refer to [release please config](https://github.com/schwannden/sim-weekly-prayers/blob/main/release-please-config.json#L12) for more types.
+   - `docs: clarify local Supabase setup`
+
+   The mapping of types to changelog sections lives in [`release-please-config.json`](https://github.com/schwannden/sim-weekly-prayers/blob/main/release-please-config.json). A breaking change is marked with `!` (e.g. `feat!: ...`) or a `BREAKING CHANGE:` footer.
 
 ## Pull Request Process
 
@@ -150,12 +163,12 @@ When you're ready to submit your changes:
    git rebase upstream/main
    ```
 
-2. **Run all checks locally**:
+2. **Run all checks locally** (the same gates CI enforces):
 
    ```bash
    npm run format
-   npm run lint:fix
-   npm run test
+   npm run lint
+   npm run build
    ```
 
 3. **Push to your fork**:
@@ -184,6 +197,14 @@ When you're ready to submit your changes:
    - A maintainer will review your PR and may request changes
    - Address any feedback by pushing new commits to your branch
    - Once approved, a maintainer will merge your PR
+
+## Releases & Deployment
+
+You don't cut releases as a contributor, but it helps to know how your merged work ships:
+
+- **Releases are commit-driven** via [release-please](https://github.com/googleapis/release-please), which parses Conventional Commit messages — this is why the commit format above matters. It maintains a release PR; merging that PR tags the version and updates `CHANGELOG.md`.
+- **Deployment is GitHub Pages, triggered on release publish** (`.github/workflows/pages.yml`). The deploy build is `npm run build:static`, which runs `vite build` then prerenders every public route to static HTML with headless Chromium (so AI crawlers and search engines see real content).
+- **CI's three gates do not exercise the prerender step**, so be mindful of the constraints documented under "Static generation / prerender" in `CLAUDE.md` — e.g. adding a new public route means registering it in `scripts/site.mjs`, and the app must keep booting with `createRoot`. Breaking these passes CI but ships empty static pages.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,17 @@ Two content domains, each with **date-based and id-based** routes:
 
 Routes must be declared **above** the `*` catch-all. SPA deep-linking on GitHub Pages works via `public/404.html`, which stashes the path in `sessionStorage.redirectPath`; `AppRoutes` reads and replays it on mount. Don't remove that handshake.
 
+### Static generation / prerender (don't break the deploy)
+The production deploy is **not** a plain `vite build`. `npm run build:static` (run by `.github/workflows/pages.yml`) does `vite build` → `npm run sitemap` → `npm run prerender`. The prerender step (`scripts/prerender.mjs`) serves `dist/` with an SPA fallback, drives **headless Puppeteer** over every route, waits for the Supabase-backed content to render, and writes the snapshot to `dist/<route>/index.html` so AI crawlers and search engines see real content instead of an empty SPA shell. Route discovery is shared with the sitemap via `scripts/site.mjs` (`getRoutes()`), which reads the live Supabase tables (`prayers`, `world_kids_news`) with the public anon key.
+
+**None of the three CI gates (`format:check`, `lint`, `build`) exercise prerender** — only the Pages deploy does. So these are invariants you must preserve or the deploy ships empty/broken static pages with no warning:
+
+- **The app must boot with `createRoot`, not `hydrate`** (`src/main.tsx`). Snapshots are re-rendered over, not hydrated; switching to `hydrate` crashes on the prerendered tree (React #299) and yields empty snapshots.
+- **Keep the loading-placeholder copy recognizable.** The prerender wait-gate blocks until `#root` text is past `載入中…`/`Loading…`; if you rename that loading state, update the regex in `scripts/prerender.mjs` or snapshots may capture the spinner.
+- **Every new public route must be added to route discovery.** Add fixed routes to `STATIC_ROUTES` and data-driven routes to `getRoutes()` in `scripts/site.mjs`, or they won't be prerendered or listed in `sitemap.xml`. Auth-gated routes (`/auth`, `/profile`) are intentionally excluded.
+- **The service worker (`public/sw.js`) is cache-first.** Prerender bypasses it per-page (`setBypassServiceWorker(true)`); keep that assumption in mind when changing SW caching, and don't make routes un-renderable without network (prerender needs Supabase reachable at build time).
+- **`puppeteer` and `sirv` are runtime build deps**, and CI caches the Chromium download (`~/.cache/puppeteer`). Don't move them to a place where `npm ci` won't install the browser.
+
 ### Data layer (Supabase)
 - `src/integrations/supabase/client.ts` and `types.ts` are **auto-generated — do not hand-edit.** The client URL/anon key are inlined (anon key is public by design; real protection is RLS).
 - Core tables: `prayers` (`week_date`, `image_url`, timestamps) and `prayer_translations` (`language`, `title`, `content`) linked per prayer. Auth is Supabase Auth with **Row Level Security**.
@@ -80,9 +91,11 @@ User-uploaded prayer images are compressed client-side (`compressorjs`) before u
 
 ## Commits, Releases & CI
 
+For the human-facing contributor workflow (fork → issue → PR, local setup, Volta/Node pin, Supabase migrations), see [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md). This section is the quick reference for the mechanics CI/release tooling enforces.
+
 - **Conventional Commits are mandatory** — release-please parses them. Recognized types map to changelog sections: `feat`, `fix`, `build`, `chore`, `refactor`, `docs`, `test` (`.github/release-please-config.json`).
 - **Releases are commit-driven.** The release-please workflow only runs on `workflow_dispatch` or when a commit message starts with `release:`. It maintains a release PR; merging it tags a version and updates `CHANGELOG.md`.
-- **Deployment = GitHub Pages on release publish** (`.github/workflows/pages.yml`), not self-hosted. A published GitHub Release triggers build + deploy; `BASE_PATH` is injected for correct asset paths.
+- **Deployment = GitHub Pages on release publish** (`.github/workflows/pages.yml`), not self-hosted. A published GitHub Release triggers `npm run build:static` (build + sitemap + headless-Chromium prerender) + deploy; `BASE_PATH` is injected for correct asset paths and `SITE_ORIGIN` (`https://prayer.simtaiwan.org`) sets canonical sitemap URLs. See **Static generation / prerender** under Architecture for the invariants that protect this deploy — CI's three gates do not test it.
 - **Pre-commit:** Husky runs `lint-staged` — ESLint+Prettier on `*.{ts,tsx}`, Prettier on `*.{js,jsx,json,css,md}`. Don't bypass with `--no-verify`.
 
 ## Conventions


### PR DESCRIPTION
## Summary

Documentation-only PR with two goals: capture the choices that protect the GitHub Pages prerender deploy in `CLAUDE.md`, and bring the contributor guide back in line with the actual repo.

### CLAUDE.md
- New **Static generation / prerender** section under Architecture explaining the `build:static` flow (Vite build → sitemap → headless-Chromium prerender) and the invariants a feature/fix must preserve, since **none of CI's three gates exercise prerender**:
  - app must boot with `createRoot`, not `hydrate` (React #299)
  - keep the `載入中…`/`Loading…` placeholder copy recognizable (prerender wait-gate)
  - register new public routes in `scripts/site.mjs`
  - cache-first service-worker bypass; Supabase must be reachable at build time
  - `puppeteer`/`sirv` build deps + CI Chromium cache
- Updated the deployment bullet to reference `build:static`/`SITE_ORIGIN` and link the new section.
- Linked `.github/CONTRIBUTING.md` from the Commits/Releases & CI section.

### .github/CONTRIBUTING.md (corrected stale content, verified against the repo)
- `npm install --legacy-peer-deps` → plain `npm install`
- Removed fictional test commands (`npm run test`, `npm run test:rls`) and the dead `tests/README.md` link — no test runner exists; replaced with the real gates (`format:check`, `lint`, `build`)
- `npm prepare` → `npm run prepare`
- Supabase project-ref `cbqslwwonnlkvblpvyrc` → `qunrljxtjzdrxkzbbkbx` (matches `config.toml`); added regenerate-types step
- Dropped non-existent `.cursor/rules/` reference → points to `CLAUDE.md`
- Volta/Node reflects the Node 24 pin + `nvm use` note
- New **Releases & Deployment** section (release-please + Pages prerender)
- **Commit standard**: enumerated the Conventional Commit types in a table, explained why the format is enforced (release-please changelog/versioning), and documented breaking-change syntax

## Test plan
- `npm run format:check` passes (Prettier clean on both files)
- Docs-only change; no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)