### PR TITLE
fix: page lang, body-text contrast, and per-page SEO/social metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,29 +1,25 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-Hant-TW">
   <head>
     <meta charset="UTF-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>Weekly Prayers for Nations| SIM Taiwan</title>
-    <meta
-      name="description"
-      content="Weekly Prayers for the Nations from SIM"
-    />
     <meta name="author" content="SIM Taiwan" />
 
-    <meta property="og:title" content="sim-weekly-prayers-hub" />
-    <meta
-      property="og:description"
-      content="Weekly Prayers for the Nations from SIM"
-    />
+    <!--
+      Title, description and og:title/og:description/og:image are set per-page at
+      runtime by react-helmet-async (see src/components/SeoHead.tsx) and captured
+      into each prerendered snapshot. They are intentionally NOT declared
+      statically here: Helmet appends its managed tags without removing static
+      ones, so duplicating them would leave two of each in every snapshot and
+      social crawlers would pick the generic static value over the per-page one.
+    -->
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/twitter-card.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@sim_taiwan" />
-    <meta name="twitter:image" content="/twitter-card.png" />
 
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "react-helmet-async": "^3.0.0",
         "react-hook-form": "^7.63.0",
         "react-i18next": "^15.6.1",
         "react-markdown": "^10.1.0",
@@ -5420,6 +5421,15 @@
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
       "license": "MIT"
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -5571,6 +5581,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6114,6 +6130,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lovable-tagger": {
@@ -7461,6 +7489,26 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.63.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
@@ -7851,6 +7899,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-helmet-async": "^3.0.0",
     "react-hook-form": "^7.63.0",
     "react-i18next": "^15.6.1",
     "react-markdown": "^10.1.0",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -76,8 +76,12 @@ async function snapshot(route) {
     // Wait until the app has rendered real content into #root — specifically,
     // past the "載入中..." / "Loading..." placeholder that all list/detail pages
     // show while their Supabase fetch is in flight. Without this the snapshot
-    // can capture the loading state. Falls through after the timeout so a page
-    // that genuinely never resolves still gets snapshotted as-is.
+    // can capture the loading state. We also require react-helmet-async to have
+    // applied the per-page <head> (it marks managed tags with `data-rh`), so the
+    // snapshot carries page-specific title/description/og rather than the static
+    // index.html shell — every public route renders a <SeoHead>. Falls through
+    // after the timeout so a page that genuinely never resolves still gets
+    // snapshotted as-is.
     await page
       .waitForFunction(
         () => {
@@ -85,7 +89,8 @@ async function snapshot(route) {
           if (!root) return false;
           const text = (root.innerText || '').trim();
           if (text.length <= 50) return false;
-          return !/載入中|Loading/i.test(text);
+          if (/載入中|Loading/i.test(text)) return false;
+          return Boolean(document.querySelector('title[data-rh]'));
         },
         { timeout: 20000 }
       )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Toaster } from '@/components/ui/toaster';
 import { Toaster as Sonner } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import { ThemeProvider } from 'next-themes';
 import { FontProvider } from '@/contexts/FontContext';
@@ -54,25 +55,27 @@ function AppRoutes() {
 }
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <FontProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <div className="min-h-screen bg-background flex flex-col">
-              <Navigation />
-              <main className="flex-1">
-                <AppRoutes />
-              </main>
-              <Footer />
-            </div>
-          </BrowserRouter>
-        </TooltipProvider>
-      </FontProvider>
-    </ThemeProvider>
-  </QueryClientProvider>
+  <HelmetProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <FontProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <div className="min-h-screen bg-background flex flex-col">
+                <Navigation />
+                <main className="flex-1">
+                  <AppRoutes />
+                </main>
+                <Footer />
+              </div>
+            </BrowserRouter>
+          </TooltipProvider>
+        </FontProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  </HelmetProvider>
 );
 
 export default App;

--- a/src/components/SeoHead.tsx
+++ b/src/components/SeoHead.tsx
@@ -1,0 +1,41 @@
+import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
+
+interface SeoHeadProps {
+  /** Page-specific title; the localized brand suffix is appended automatically. */
+  title: string;
+  /** Plain-text description for <meta name="description"> and og:description. */
+  description?: string;
+  /** Absolute image URL for og:image (e.g. a Supabase Storage URL). */
+  image?: string;
+}
+
+// Site-wide social-share fallback used when a page has no image of its own.
+const DEFAULT_OG_IMAGE = '/twitter-card.png';
+
+/**
+ * Sets per-page document head (title + description + Open Graph) via
+ * react-helmet-async. On live visits this keeps the browser-tab title and
+ * social-share metadata correct per route; at build time the prerender step
+ * (scripts/prerender.mjs) waits for these tags before snapshotting, so AI
+ * crawlers and search engines see unique metadata per page instead of the
+ * static index.html shell.
+ */
+const SeoHead = ({ title, description, image }: SeoHeadProps) => {
+  const { t } = useTranslation();
+  const suffix = t('meta.titleSuffix');
+  const fullTitle = title ? `${title} | ${suffix}` : suffix;
+
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      <meta property="og:title" content={fullTitle} />
+      {description && <meta name="description" content={description} />}
+      {description && <meta property="og:description" content={description} />}
+      <meta property="og:image" content={image || DEFAULT_OG_IMAGE} />
+      <meta name="twitter:image" content={image || DEFAULT_OG_IMAGE} />
+    </Helmet>
+  );
+};
+
+export default SeoHead;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -29,9 +29,25 @@ i18n.use(initReactI18next).init({
   },
 });
 
-// Save language changes to localStorage
+// Map an i18n language code to a valid BCP-47 tag for <html lang>. Screen
+// readers and search engines rely on this; the app defaults to zh-TW content,
+// so the document must not advertise itself as English.
+const toHtmlLang = (lng: string) => (lng === 'zh-TW' ? 'zh-Hant-TW' : lng);
+
+const applyHtmlLang = (lng: string) => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = toHtmlLang(lng);
+  }
+};
+
+// Sync on initial load (covers the case where the saved preference differs from
+// the static lang baked into index.html) and on every subsequent switch.
+applyHtmlLang(i18n.language);
+
+// Save language changes to localStorage and keep <html lang> in sync.
 i18n.on('languageChanged', (lng) => {
   localStorage.setItem('language-preference', lng);
+  applyHtmlLang(lng);
 });
 
 export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -75,7 +75,14 @@
   },
   "meta": {
     "title": "SIM Weekly Prayers Hub",
-    "description": "Weekly prayers for nations around the world"
+    "description": "Weekly prayers for nations around the world",
+    "titleSuffix": "SIM Taiwan",
+    "prayers": {
+      "description": "Browse weekly prayers that follow current world events — pray with us for the nations."
+    },
+    "familyPrayers": {
+      "description": "Family-friendly weekly prayers and World Kids News to pray for the nations together with your children."
+    }
   },
   "auth": {
     "welcome": "Welcome to SIM Prayer",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -86,7 +86,14 @@
   },
   "meta": {
     "title": "SIM 每週禱告中心",
-    "description": "為世界各國的每週禱告"
+    "description": "為世界各國的每週禱告",
+    "titleSuffix": "SIM 台灣",
+    "prayers": {
+      "description": "瀏覽每週禱告，跟著時事脈動，與我們同為世界萬國禱告。"
+    },
+    "familyPrayers": {
+      "description": "適合全家大小的每週禱告與世界兒童新聞，帶著孩子一起為萬國禱告。"
+    }
   },
   "auth": {
     "welcome": "歡迎來到 SIM 禱告",

--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,8 @@ All colors MUST be HSL.
     --secondary-foreground: 215 25% 25%;
 
     --muted: 210 25% 96%;
-    --muted-foreground: 215 15% 55%;
+    /* Darkened from 215 15% 55% (~3.2:1) to meet WCAG AA 4.5:1 on --background. */
+    --muted-foreground: 215 18% 42%;
 
     --accent: 195 85% 88%;
     --accent-foreground: 215 25% 25%;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -13,6 +13,14 @@ export function toMetaDescription(markdown: string, maxLength = 155): string {
     .replace(/\s+/g, ' ') // collapse whitespace
     .trim();
 
-  if (text.length <= maxLength) return text;
-  return text.slice(0, maxLength - 1).trimEnd() + '…';
+  // Slice by code points (Array.from), not UTF-16 units, so truncation never
+  // splits a surrogate pair (e.g. an emoji) into a broken trailing glyph.
+  const chars = Array.from(text);
+  if (chars.length <= maxLength) return text;
+  return (
+    chars
+      .slice(0, maxLength - 1)
+      .join('')
+      .trimEnd() + '…'
+  );
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,18 @@
+// Build a concise, plain-text meta description from prayer markdown content.
+// Strips markdown syntax (headings, emphasis, links, images, code) so search
+// engines and AI crawlers get clean snippet text, then truncates to a length
+// that fits within the typical search-result snippet.
+export function toMetaDescription(markdown: string, maxLength = 155): string {
+  const text = (markdown || '')
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+    .replace(/`([^`]*)`/g, '$1') // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links -> link text
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '') // ATX headings
+    .replace(/[*_~>#]/g, ' ') // residual markdown symbols
+    .replace(/\s+/g, ' ') // collapse whitespace
+    .trim();
+
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 1).trimEnd() + '…';
+}

--- a/src/pages/FamilyPrayerDetail.tsx
+++ b/src/pages/FamilyPrayerDetail.tsx
@@ -138,6 +138,7 @@ const FamilyPrayerDetail = () => {
   if (!familyPrayer) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/10 flex items-center justify-center">
+        <SeoHead title={t('prayer.noResults')} />
         <div className="text-center">
           <div className="text-muted-foreground mb-4">
             {t('prayer.noResults')}

--- a/src/pages/FamilyPrayerDetail.tsx
+++ b/src/pages/FamilyPrayerDetail.tsx
@@ -10,6 +10,8 @@ import { Label } from '@/components/ui/label';
 import { ArrowLeft, Calendar } from 'lucide-react';
 import WorldKidsNewsSlides from '@/components/WorldKidsNewsSlides';
 import SocialShareDropdown from '@/components/SocialShareDropdown';
+import SeoHead from '@/components/SeoHead';
+import { toMetaDescription } from '@/lib/seo';
 
 interface FamilyPrayer {
   id: string;
@@ -157,6 +159,11 @@ const FamilyPrayerDetail = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/10">
+      <SeoHead
+        title={`${safeTitle} · ${formatDate(familyPrayer.week_date)}`}
+        description={toMetaDescription(translation?.content || '')}
+        image={familyPrayer.image_urls?.[0]}
+      />
       <div className="container mx-auto px-4 py-8">
         {/* Back Button */}
         <div className="mb-6 flex items-center justify-between">

--- a/src/pages/FamilyPrayers.tsx
+++ b/src/pages/FamilyPrayers.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import FamilyPrayerCard from '@/components/FamilyPrayerCard';
 import SearchBox from '@/components/SearchBox';
 import PrayerDialog from '@/components/PrayerDialog';
+import SeoHead from '@/components/SeoHead';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import {
@@ -214,6 +215,10 @@ const FamilyPrayers = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/10">
+      <SeoHead
+        title={t('nav.familyPrayers')}
+        description={t('meta.familyPrayers.description')}
+      />
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
         <div className="text-center mb-8">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import PrayerCard from '@/components/PrayerCard';
 import FamilyPrayerCard from '@/components/FamilyPrayerCard';
+import SeoHead from '@/components/SeoHead';
 import { ArrowRight, Globe2 } from 'lucide-react';
 
 interface Prayer {
@@ -113,6 +114,7 @@ const Home = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/10">
+      <SeoHead title={t('home.title')} description={t('home.subtitle')} />
       {/* Hero Section */}
       <section className="py-20 px-4">
         <div className="container mx-auto text-center">

--- a/src/pages/PrayerDetail.tsx
+++ b/src/pages/PrayerDetail.tsx
@@ -147,6 +147,7 @@ const PrayerDetail = () => {
   if (!prayer) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/10 flex items-center justify-center">
+        <SeoHead title={t('prayer.noResults')} />
         <div className="text-center">
           <div className="text-muted-foreground mb-4">
             {t('prayer.noResults')}

--- a/src/pages/PrayerDetail.tsx
+++ b/src/pages/PrayerDetail.tsx
@@ -10,6 +10,8 @@ import { Label } from '@/components/ui/label';
 import { ArrowLeft, Calendar } from 'lucide-react';
 import SocialShareDropdown from '@/components/SocialShareDropdown';
 import WorldKidsNewsSlides from '@/components/WorldKidsNewsSlides';
+import SeoHead from '@/components/SeoHead';
+import { toMetaDescription } from '@/lib/seo';
 
 interface Prayer {
   id: string;
@@ -169,6 +171,11 @@ const PrayerDetail = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/10">
+      <SeoHead
+        title={`${safeTitle} · ${formatDate(prayer.week_date)}`}
+        description={toMetaDescription(rawContent)}
+        image={safeImageUrl || undefined}
+      />
       <div className="container mx-auto px-4 py-8">
         {/* Back Button */}
         <div className="mb-6">

--- a/src/pages/Prayers.tsx
+++ b/src/pages/Prayers.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import PrayerCard from '@/components/PrayerCard';
 import SearchBox from '@/components/SearchBox';
 import PrayerDialog from '@/components/PrayerDialog';
+import SeoHead from '@/components/SeoHead';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import {
@@ -274,6 +275,10 @@ const Prayers = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/10">
+      <SeoHead
+        title={t('nav.prayers')}
+        description={t('meta.prayers.description')}
+      />
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
         <div className="text-center mb-8">


### PR DESCRIPTION
Fixes four launch-blocking accessibility / SEO / GEO findings from the production audit (C1–C4). Each finding was verified against the actual codebase and the Puppeteer-prerender deploy before fixing.

## What changed

### C1 — Page language (A11y, WCAG 3.1.1)
`<html lang>` was hardcoded `"en"` while all content defaults to Traditional Chinese, and `document.documentElement.lang` was never updated on language switch.
- `index.html` → `lang="zh-Hant-TW"` (matches the default zh-TW render the prerender captures).
- `src/i18n/index.ts` now syncs `document.documentElement.lang` to the active language on init and on every switch (`zh-TW`→`zh-Hant-TW`, `en`→`en`) — so the bilingual toggle stays correct.

### C2 — Low-contrast body text (A11y, WCAG 1.4.3)
Light-mode `--muted-foreground` measured ~3.2:1 (nav, card text, dates, hero subtitle, footer).
- `src/index.css`: `215 15% 55%` → `215 18% 42%` (~4.6:1).
- **Dark mode left untouched** — it already passes (~13.8:1); the audit's suggested single global value would have *broken* dark mode (verified).

### C3 / C4 — Per-page metadata & dev-slug og:title (SEO + GEO)
Every page served the identical static `<title>`/description/og, and `og:title` was the dev slug `sim-weekly-prayers-hub`.
- Added `react-helmet-async` + a reusable `SeoHead` component and a `toMetaDescription` markdown→snippet helper.
- Every public page now emits a unique `title` / `description` / `og:title` / `og:description` / `og:image` / `twitter:image` (prayer headline + date → title, content lead sentence → description, prayer image → og:image).
- Removed the overlapping **static** head tags from `index.html`: Helmet appends its managed tags without removing static ones, so leaving them would put **two** of each in every snapshot and social crawlers would pick the generic static value over the per-page one.

### Prerender hardening (protects the deploy — no CI gate exercises it)
- `scripts/prerender.mjs` wait-gate now also blocks until react-helmet-async has applied the head (`title[data-rh]`), so crawler snapshots can never capture the static shell head before Helmet runs.

## Verification
- ✅ All three CI gates: `format:check`, `lint`, `build`.
- ✅ `npm run build:static` (full prerender) — inspected generated snapshots:
  - `<html lang="zh-Hant-TW">`
  - Unique per-prayer `<title>` (e.g. `剛果與盧安達簽和平協議 求主賜平安 · 2025年7月6日 | SIM 台灣`)
  - `og:title`/`og:description` are per-page (no more dev slug); `og:image` is the prayer's Supabase image
  - **Exactly one** of each head tag per snapshot (duplicate-tag regression confirmed fixed)

## Out of scope (noted, not fixed here)
- `canonical` / `og:url` tags — would bake in `localhost` from `window.location.origin` during prerender; needs a separate origin-config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)